### PR TITLE
login与register页面的footer渲染错误

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,9 @@
       <el-main>
         <RouterView/>
       </el-main>
-      <Footer/>
+      <div v-if="!$route.meta.hideFooter">
+        <Footer/>
+      </div>
     </el-container>
     
   </el-config-provider>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,11 +14,13 @@ const routes = [
   {
     path: '/login',
     name: 'login',
+    meta: { hideFooter: true },
     component: () => import("../views/Login.vue")
   },
   {
     path: '/register',
     name: 'register',
+    meta: { hideFooter: true },
     component: () => import("../views/Register.vue")
   },
   {
@@ -60,7 +62,7 @@ const routes = [
     path: '/Seller/EditGoods/:goodsId',
     name: 'EditGoods',
     component: () => import("../views/Seller/EditGoods.vue")
-  },
+  }, 
   {
     path: '/Seller/Goodslist',
     name: 'Goodslist',


### PR DESCRIPTION
login与register页面的footer渲染到了屏幕中间，与图片重叠了，暂不知道是哪里的样式发生了冲突，索性不在这两个页面渲染footer了